### PR TITLE
add hostmetricsreceiver filesystem utilization

### DIFF
--- a/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
@@ -57,6 +57,7 @@ var standardMetrics = []string{
 	"system.disk.operation_time",
 	"system.disk.pending_operations",
 	"system.filesystem.usage",
+	"system.filesystem.utilization",
 	"system.memory.usage",
 	"system.network.connections",
 	"system.network.dropped",

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/documentation.md
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/documentation.md
@@ -10,6 +10,7 @@ These are the metrics available for this scraper.
 | ---- | ----------- | ---- | ---- | ---------- |
 | **system.filesystem.inodes.usage** | FileSystem inodes used. | {inodes} | Sum(Int) | <ul> <li>device</li> <li>mode</li> <li>mountpoint</li> <li>type</li> <li>state</li> </ul> |
 | **system.filesystem.usage** | Filesystem bytes used. | By | Sum(Int) | <ul> <li>device</li> <li>mode</li> <li>mountpoint</li> <li>type</li> <li>state</li> </ul> |
+| **system.filesystem.utilization** | Percentage of filesystem bytes used. | 1 | Gauge(Double) | <ul> <li>device</li> <li>mode</li> <li>mountpoint</li> <li>type</li> <li>state</li> </ul> |
 
 **Highlighted metrics** are emitted by default. Other metrics are optional and not emitted by default.
 Any metric can be enabled or disabled with the following scraper configuration:

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_others.go
@@ -28,9 +28,20 @@ const fileSystemStatesLen = 2
 func (s *scraper) recordFileSystemUsageMetric(now pdata.Timestamp, deviceUsages []*deviceUsage) {
 	for _, deviceUsage := range deviceUsages {
 		s.mb.RecordSystemFilesystemUsageDataPoint(
-			now, int64(deviceUsage.usage.Used), deviceUsage.partition.Device, getMountMode(deviceUsage.partition.Opts), deviceUsage.partition.Mountpoint, deviceUsage.partition.Fstype, metadata.AttributeState.Used)
+			now, int64(deviceUsage.usage.Used),
+			deviceUsage.partition.Device, getMountMode(deviceUsage.partition.Opts),
+			deviceUsage.partition.Mountpoint, deviceUsage.partition.Fstype,
+			metadata.AttributeState.Used)
 		s.mb.RecordSystemFilesystemUsageDataPoint(
-			now, int64(deviceUsage.usage.Free), deviceUsage.partition.Device, getMountMode(deviceUsage.partition.Opts), deviceUsage.partition.Mountpoint, deviceUsage.partition.Fstype, metadata.AttributeState.Free)
+			now, int64(deviceUsage.usage.Free),
+			deviceUsage.partition.Device, getMountMode(deviceUsage.partition.Opts),
+			deviceUsage.partition.Mountpoint, deviceUsage.partition.Fstype,
+			metadata.AttributeState.Free)
+		s.mb.RecordSystemFilesystemUtilizationDataPoint(
+			now, deviceUsage.usage.UsedPercent,
+			deviceUsage.partition.Device, getMountMode(deviceUsage.partition.Opts),
+			deviceUsage.partition.Mountpoint, deviceUsage.partition.Fstype,
+			metadata.AttributeState.Utilized)
 	}
 }
 

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_unix.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_unix.go
@@ -30,15 +30,23 @@ func (s *scraper) recordFileSystemUsageMetric(now pdata.Timestamp, deviceUsages 
 		s.mb.RecordSystemFilesystemUsageDataPoint(
 			now, int64(deviceUsage.usage.Used),
 			deviceUsage.partition.Device, getMountMode(deviceUsage.partition.Opts), deviceUsage.partition.Mountpoint,
-			deviceUsage.partition.Fstype, metadata.AttributeState.Used)
+			deviceUsage.partition.Fstype,
+			metadata.AttributeState.Used)
 		s.mb.RecordSystemFilesystemUsageDataPoint(
 			now, int64(deviceUsage.usage.Free),
 			deviceUsage.partition.Device, getMountMode(deviceUsage.partition.Opts),
-			deviceUsage.partition.Mountpoint, deviceUsage.partition.Fstype, metadata.AttributeState.Free)
+			deviceUsage.partition.Mountpoint, deviceUsage.partition.Fstype,
+			metadata.AttributeState.Free)
 		s.mb.RecordSystemFilesystemUsageDataPoint(
 			now, int64(deviceUsage.usage.Total-deviceUsage.usage.Used-deviceUsage.usage.Free),
 			deviceUsage.partition.Device, getMountMode(deviceUsage.partition.Opts),
-			deviceUsage.partition.Mountpoint, deviceUsage.partition.Fstype, metadata.AttributeState.Reserved)
+			deviceUsage.partition.Mountpoint, deviceUsage.partition.Fstype,
+			metadata.AttributeState.Reserved)
+		s.mb.RecordSystemFilesystemUtilizationDataPoint(
+			now, deviceUsage.usage.UsedPercent,
+			deviceUsage.partition.Device, getMountMode(deviceUsage.partition.Opts),
+			deviceUsage.partition.Mountpoint, deviceUsage.partition.Fstype,
+			metadata.AttributeState.Utilized)
 	}
 }
 

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/internal/metadata/generated_metrics_v2.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/internal/metadata/generated_metrics_v2.go
@@ -17,6 +17,7 @@ type MetricSettings struct {
 type MetricsSettings struct {
 	SystemFilesystemInodesUsage MetricSettings `mapstructure:"system.filesystem.inodes.usage"`
 	SystemFilesystemUsage       MetricSettings `mapstructure:"system.filesystem.usage"`
+	SystemFilesystemUtilization MetricSettings `mapstructure:"system.filesystem.utilization"`
 }
 
 func DefaultMetricsSettings() MetricsSettings {
@@ -25,6 +26,9 @@ func DefaultMetricsSettings() MetricsSettings {
 			Enabled: true,
 		},
 		SystemFilesystemUsage: MetricSettings{
+			Enabled: true,
+		},
+		SystemFilesystemUtilization: MetricSettings{
 			Enabled: true,
 		},
 	}
@@ -144,12 +148,68 @@ func newMetricSystemFilesystemUsage(settings MetricSettings) metricSystemFilesys
 	return m
 }
 
+type metricSystemFilesystemUtilization struct {
+	data     pdata.Metric   // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills system.filesystem.utilization metric with initial data.
+func (m *metricSystemFilesystemUtilization) init() {
+	m.data.SetName("system.filesystem.utilization")
+	m.data.SetDescription("Percentage of filesystem bytes used.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pdata.MetricDataTypeGauge)
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricSystemFilesystemUtilization) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val float64, deviceAttributeValue string, modeAttributeValue string, mountpointAttributeValue string, typeAttributeValue string, stateAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetDoubleVal(val)
+	dp.Attributes().Insert(A.Device, pdata.NewAttributeValueString(deviceAttributeValue))
+	dp.Attributes().Insert(A.Mode, pdata.NewAttributeValueString(modeAttributeValue))
+	dp.Attributes().Insert(A.Mountpoint, pdata.NewAttributeValueString(mountpointAttributeValue))
+	dp.Attributes().Insert(A.Type, pdata.NewAttributeValueString(typeAttributeValue))
+	dp.Attributes().Insert(A.State, pdata.NewAttributeValueString(stateAttributeValue))
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSystemFilesystemUtilization) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSystemFilesystemUtilization) emit(metrics pdata.MetricSlice) {
+	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSystemFilesystemUtilization(settings MetricSettings) metricSystemFilesystemUtilization {
+	m := metricSystemFilesystemUtilization{settings: settings}
+	if settings.Enabled {
+		m.data = pdata.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user settings.
 type MetricsBuilder struct {
 	startTime                         pdata.Timestamp
 	metricSystemFilesystemInodesUsage metricSystemFilesystemInodesUsage
 	metricSystemFilesystemUsage       metricSystemFilesystemUsage
+	metricSystemFilesystemUtilization metricSystemFilesystemUtilization
 }
 
 // metricBuilderOption applies changes to default metrics builder.
@@ -167,6 +227,7 @@ func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption)
 		startTime:                         pdata.NewTimestampFromTime(time.Now()),
 		metricSystemFilesystemInodesUsage: newMetricSystemFilesystemInodesUsage(settings.SystemFilesystemInodesUsage),
 		metricSystemFilesystemUsage:       newMetricSystemFilesystemUsage(settings.SystemFilesystemUsage),
+		metricSystemFilesystemUtilization: newMetricSystemFilesystemUtilization(settings.SystemFilesystemUtilization),
 	}
 	for _, op := range options {
 		op(mb)
@@ -180,6 +241,7 @@ func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption)
 func (mb *MetricsBuilder) Emit(metrics pdata.MetricSlice) {
 	mb.metricSystemFilesystemInodesUsage.emit(metrics)
 	mb.metricSystemFilesystemUsage.emit(metrics)
+	mb.metricSystemFilesystemUtilization.emit(metrics)
 }
 
 // RecordSystemFilesystemInodesUsageDataPoint adds a data point to system.filesystem.inodes.usage metric.
@@ -190,6 +252,11 @@ func (mb *MetricsBuilder) RecordSystemFilesystemInodesUsageDataPoint(ts pdata.Ti
 // RecordSystemFilesystemUsageDataPoint adds a data point to system.filesystem.usage metric.
 func (mb *MetricsBuilder) RecordSystemFilesystemUsageDataPoint(ts pdata.Timestamp, val int64, deviceAttributeValue string, modeAttributeValue string, mountpointAttributeValue string, typeAttributeValue string, stateAttributeValue string) {
 	mb.metricSystemFilesystemUsage.recordDataPoint(mb.startTime, ts, val, deviceAttributeValue, modeAttributeValue, mountpointAttributeValue, typeAttributeValue, stateAttributeValue)
+}
+
+// RecordSystemFilesystemUtilizationDataPoint adds a data point to system.filesystem.utilization metric.
+func (mb *MetricsBuilder) RecordSystemFilesystemUtilizationDataPoint(ts pdata.Timestamp, val float64, deviceAttributeValue string, modeAttributeValue string, mountpointAttributeValue string, typeAttributeValue string, stateAttributeValue string) {
+	mb.metricSystemFilesystemUtilization.recordDataPoint(mb.startTime, ts, val, deviceAttributeValue, modeAttributeValue, mountpointAttributeValue, typeAttributeValue, stateAttributeValue)
 }
 
 // Reset resets metrics builder to its initial state. It should be used when external metrics source is restarted,
@@ -229,8 +296,10 @@ var AttributeState = struct {
 	Free     string
 	Reserved string
 	Used     string
+	Utilized string
 }{
 	"free",
 	"reserved",
 	"used",
+	"utilized",
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/metadata.yaml
@@ -12,7 +12,7 @@ attributes:
 
   state:
     description: Breakdown of filesystem usage by type.
-    enum: [free, reserved, used]
+    enum: [free, reserved, used, utilized]
 
   type:
     description: Filesystem type, such as, "ext4", "tmpfs", etc.
@@ -36,4 +36,12 @@ metrics:
       value_type: int
       aggregation: cumulative
       monotonic: false
+    attributes: [device, mode, mountpoint, type, state]
+
+  system.filesystem.utilization:
+    enabled: true
+    description: Percentage of filesystem bytes used.
+    unit: 1
+    gauge:
+      value_type: double
     attributes: [device, mode, mountpoint, type, state]


### PR DESCRIPTION
**Description:** <Describe what has changed.>
- This PR adds `system.filesystem.utilization` to `hostmetricsreceiver`

**Link to tracking Issue:**
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/6221

**Testing:** 
- Current tests were updated
- Did a sanity check with Ubuntu VM


**Documentation:** 
- Added to scrapper docs.